### PR TITLE
Include shared DB connection in controllers

### DIFF
--- a/controller/actionCreateEvent.php
+++ b/controller/actionCreateEvent.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once("../model/connexion.php");
 require_once("../model/eventModel.php");
 
 

--- a/controller/actionLogin.php
+++ b/controller/actionLogin.php
@@ -1,10 +1,6 @@
 <?php
 session_start();
-$conn = mysqli_connect("localhost", "root", "", "yolou");
-
-if (!$conn) {
-    die("Erreur de connexion à la base.");
-}
+require_once("../model/connexion.php");
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $email = $_POST['email'];

--- a/controller/actionRegister.php
+++ b/controller/actionRegister.php
@@ -1,4 +1,5 @@
 <?php
+require_once("../model/connexion.php");
 require_once("model/userModel.php");
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {


### PR DESCRIPTION
## Summary
- load `connexion.php` in login controller instead of an inline connection
- ensure register and create-event controllers also require `connexion.php`

## Testing
- `php -l controller/actionLogin.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843490df854833380058d5ddcb9bdf3