### PR TITLE
Improve registration flow with feedback messages

### DIFF
--- a/controller/actionRegister.php
+++ b/controller/actionRegister.php
@@ -1,5 +1,5 @@
 <?php
-require_once("model/userModel.php");
+require_once("../model/userModel.php");
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $nom = htmlspecialchars($_POST['nom']);
@@ -7,8 +7,15 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $mot_de_passe = password_hash($_POST['mot_de_passe'], PASSWORD_DEFAULT);
     $role = $_POST['role'];
 
+    // Vérifie si l'email est déjà présent dans la base
+    if (getUserByEmail($email)) {
+        header("Location: ../view/register.php?success=0&error=email");
+        exit();
+    }
+
+    // Ajout de l'utilisateur puis redirection avec message de succès
     ajouterUtilisateur($nom, $email, $mot_de_passe, $role);
-    header("Location: view/login.php");
+    header("Location: ../view/register.php?success=1");
     exit();
 }
 ?>

--- a/view/register.php
+++ b/view/register.php
@@ -1,5 +1,17 @@
 <?php include "header.php"; ?>
 
+<?php if (isset($_GET['success'])): ?>
+  <?php if ($_GET['success'] == '1'): ?>
+    <p style="color:green; text-align:center;">Inscription réussie. Vous pouvez maintenant vous connecter.</p>
+  <?php else: ?>
+    <?php if (isset($_GET['error']) && $_GET['error'] === 'email'): ?>
+      <p style="color:red; text-align:center;">Cet email est déjà enregistré.</p>
+    <?php else: ?>
+      <p style="color:red; text-align:center;">Une erreur s'est produite lors de l'inscription.</p>
+    <?php endif; ?>
+  <?php endif; ?>
+<?php endif; ?>
+
 <h2>Inscription</h2>
 
 <form method="post" action="controller/actionRegister.php">


### PR DESCRIPTION
## Summary
- validate unique email in registration controller
- redirect to registration page with success/error query params
- display success or error messages on the registration form

## Testing
- `php -l controller/actionRegister.php` *(fails: command not found)*
- `php -l view/register.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843491a7bf08333b906b0895629874d